### PR TITLE
docs: update stellar Windows notes now that Windows is supported

### DIFF
--- a/content/projects/starship-switcher.mdx
+++ b/content/projects/starship-switcher.mdx
@@ -19,10 +19,8 @@ Check it out:
 
 ![Starship theme switcher demo](/project-images/stellar-demo.gif)
 
-stellar does not support windows yet (or in other words, windows does not support stellar yet (symlinks)), 
-so if you are a windows user, either switch to linux (or apple if you have to ;) ) or use the old starship switcher below.  
-It can still switch between local starship configs, and you can get the configs manually by going to a themes details page, 
-and checking out the latest versions details.
+The starship theme switcher below is the older predecessor of stellar, kept here for reference.  
+stellar itself now works on every platform, including windows — there it copies the config instead of using symlinks (which windows handles poorly), so you can just use stellar on any OS.
 
 ---
 

--- a/content/projects/stellar.mdx
+++ b/content/projects/stellar.mdx
@@ -79,7 +79,7 @@ and then switch to them using `stellar apply local/<your-theme>`.
 You can similarily copy one existing downloaded theme to the `stellar/local` folder, edit it, 
 and then switch to it using `stellar apply`.
 
-Because stellar is using a symlink to the currently selected config file, you get hot-reload as well.
+On Linux and macOS you get hot-reload (because stellar uses a symlink to the currently selected config file), on Windows it copies the config instead (Windows can't really do symlinks), so re-run `stellar apply` after editing a local config.
 
 ## Contributing
 


### PR DESCRIPTION
stellar now works on Windows (copies the config instead of symlinking), so drop the "does not support windows" note on the starship-switcher page and caveat the symlink/hot-reload line on the stellar page for Windows.